### PR TITLE
Updating PyPI version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AmpliconSuiteAggregator"
-version = "2.1.3"
+version = "5.1.0"
 authors = [
   { name="Edwin Huang", email="edwin5588@gmail.com" },
   { name="Thorin Tabor", email="tmtabor@cloud.ucsd.edu" },


### PR DESCRIPTION
Updating PyPI version number to match version number in AmpliconSuiteAggregator.py. An updated version number is necessary for PyPI release.